### PR TITLE
Remove the explicit include of the mandrill library

### DIFF
--- a/forms_intro.pages.inc
+++ b/forms_intro.pages.inc
@@ -1,6 +1,4 @@
 <?php
-require_once (libraries_get_path('mandrill') .'/src/Mandrill.php');
-
 /**
  * Implements hook_form().
  */


### PR DESCRIPTION
Using the DevelMailLog system everything looks good and is functioning. I removed the explicit include of mandrill with this pull request. 
